### PR TITLE
Use the Go version from `go.mod` in the CI pipeline.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Setup
       uses: actions/setup-go@v5
       with:
-        go-version: '1.23'
+        go-version-file: 'go.mod'
 
     - name: Build
       run: go build -v ./...


### PR DESCRIPTION
Rely on the version of Go set in the `go.mod`.